### PR TITLE
feat: add dynamic model fetching from Anthropic API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Settings use the `FreewritingCleanupSettings` interface with modular defaults:
 ```typescript
 interface FreewritingCleanupSettings {
     apiKey: string;
-    model: AnthropicModel;
+    model: string; // Dynamic model ID fetched from Anthropic API
     cleanupPrompt: string;
     enableCommentary: boolean;
     commentaryStyle: CommentaryStyle;

--- a/services/cleanupService.ts
+++ b/services/cleanupService.ts
@@ -37,7 +37,7 @@ export class CleanupService {
         const startTime = Date.now();
 
         try {
-            const { cleanedText, commentary } = await this.client.cleanupText(
+            const { cleanedText, commentary, usage } = await this.client.cleanupText(
                 text,
                 settings.model,
                 settings.cleanupPrompt,
@@ -53,8 +53,8 @@ export class CleanupService {
                 timestamp: new Date(),
                 model: settings.model,
                 tokensUsed: {
-                    input: 0, // We don't have access to this from the response
-                    output: 0  // We don't have access to this from the response
+                    input: usage?.input_tokens ?? 0,
+                    output: usage?.output_tokens ?? 0
                 }
             };
 

--- a/services/cleanupService.ts
+++ b/services/cleanupService.ts
@@ -6,10 +6,15 @@ import { AnthropicClient } from '../api/anthropicClient';
 import { FreewritingCleanupSettings, CleanupResult, ANTHROPIC_LIMITS } from '../types';
 
 export class CleanupService {
-    private anthropicClient: AnthropicClient;
+    private client: AnthropicClient;
+
+    // Expose client for ModelService
+    get anthropicClient(): AnthropicClient {
+        return this.client;
+    }
 
     constructor(apiKey: string) {
-        this.anthropicClient = new AnthropicClient(apiKey);
+        this.client = new AnthropicClient(apiKey);
     }
 
     // MARK: - Public Methods
@@ -20,7 +25,7 @@ export class CleanupService {
             throw new Error('No text selected for cleanup');
         }
 
-        if (!this.anthropicClient.validateApiKey()) {
+        if (!this.client.validateApiKey()) {
             throw new Error('API key is not configured. Please check your plugin settings.');
         }
 
@@ -32,7 +37,7 @@ export class CleanupService {
         const startTime = Date.now();
 
         try {
-            const { cleanedText, commentary } = await this.anthropicClient.cleanupText(
+            const { cleanedText, commentary } = await this.client.cleanupText(
                 text,
                 settings.model,
                 settings.cleanupPrompt,
@@ -74,7 +79,7 @@ export class CleanupService {
             outputTokens?: number;
         };
     }> {
-        if (!this.anthropicClient.validateApiKey()) {
+        if (!this.client.validateApiKey()) {
             return {
                 success: false,
                 message: 'API key is not configured'
@@ -82,7 +87,7 @@ export class CleanupService {
         }
 
         try {
-            const result = await this.anthropicClient.testConnection(settings.model);
+            const result = await this.client.testConnection(settings.model);
             return result;
         } catch (error) {
             return {
@@ -105,7 +110,7 @@ export class CleanupService {
     // MARK: - Configuration Methods
 
     updateApiKey(apiKey: string): void {
-        this.anthropicClient.updateApiKey(apiKey);
+        this.client.updateApiKey(apiKey);
     }
 
     validateSettings(settings: FreewritingCleanupSettings): {

--- a/services/modelService.ts
+++ b/services/modelService.ts
@@ -1,0 +1,129 @@
+// ABOUTME: Service for managing Claude model list from Anthropic API
+// ABOUTME: Handles fetching, caching with 24-hour TTL, and fallback to hardcoded list
+
+import { Notice } from 'obsidian';
+import { AnthropicClient } from '../api/anthropicClient';
+import { ModelInfo, ModelCache, ANTHROPIC_MODELS } from '../types';
+
+export interface ModelOption {
+    id: string;
+    displayName: string;
+}
+
+export class ModelService {
+    private anthropicClient: AnthropicClient;
+    private modelCache: ModelCache | null = null;
+    private readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+    constructor(anthropicClient: AnthropicClient) {
+        this.anthropicClient = anthropicClient;
+    }
+
+    // MARK: - Public Methods
+
+    /**
+     * Get available models with caching and fallback logic
+     * Returns models from cache if valid, otherwise fetches from API
+     * Falls back to hardcoded list if API fails
+     */
+    async getAvailableModels(): Promise<ModelOption[]> {
+        // Check if we have a valid cache
+        if (this.isCacheValid() && this.modelCache) {
+            return this.formatModels(this.modelCache.models);
+        }
+
+        // Try to fetch from API
+        try {
+            const response = await this.anthropicClient.fetchModels();
+            this.updateCache(response.data);
+            return this.formatModels(response.data);
+        } catch (error) {
+            console.error('Failed to fetch models from API:', error);
+            new Notice('Fetching current models failed. Using hardcoded fallback list.');
+            return this.getFallbackModels();
+        }
+    }
+
+    /**
+     * Force refresh the model list from API
+     * Used when user changes API key
+     */
+    async refreshModels(): Promise<ModelOption[]> {
+        try {
+            const response = await this.anthropicClient.fetchModels();
+            this.updateCache(response.data);
+            return this.formatModels(response.data);
+        } catch (error) {
+            console.error('Failed to refresh models from API:', error);
+            new Notice('Fetching current models failed. Using hardcoded fallback list.');
+            return this.getFallbackModels();
+        }
+    }
+
+    /**
+     * Load cache from plugin data
+     */
+    loadCache(cache: ModelCache | null): void {
+        this.modelCache = cache;
+    }
+
+    /**
+     * Get current cache for saving to plugin data
+     */
+    getCache(): ModelCache | null {
+        return this.modelCache;
+    }
+
+    /**
+     * Clear the cache (for testing or manual refresh)
+     */
+    clearCache(): void {
+        this.modelCache = null;
+    }
+
+    // MARK: - Private Methods
+
+    /**
+     * Check if the current cache is still valid (within TTL)
+     */
+    private isCacheValid(): boolean {
+        if (!this.modelCache) {
+            return false;
+        }
+
+        const now = Date.now();
+        const age = now - this.modelCache.fetchedAt;
+        return age < this.CACHE_TTL_MS;
+    }
+
+    /**
+     * Update cache with new model data
+     */
+    private updateCache(models: ModelInfo[]): void {
+        this.modelCache = {
+            models,
+            fetchedAt: Date.now()
+        };
+    }
+
+    /**
+     * Format ModelInfo array to ModelOption array for dropdown
+     * Uses display_name if available, otherwise falls back to id
+     */
+    private formatModels(models: ModelInfo[]): ModelOption[] {
+        return models.map(model => ({
+            id: model.id,
+            displayName: model.display_name || model.id
+        }));
+    }
+
+    /**
+     * Get fallback models from hardcoded list
+     */
+    private getFallbackModels(): ModelOption[] {
+        return ANTHROPIC_MODELS.map(id => ({
+            id,
+            displayName: id
+        }));
+    }
+}

--- a/services/modelService.ts
+++ b/services/modelService.ts
@@ -158,14 +158,14 @@ export class ModelService {
 
     /**
      * Format ModelInfo array to ModelOption array for dropdown
-     * Uses display_name if available, otherwise falls back to id
+     * Uses display_name from API for user-friendly model names
      * Sorted by displayName for consistent UX across cache/API ordering
      */
     private formatModels(models: ModelInfo[]): ModelOption[] {
         return models
             .map(model => ({
                 id: model.id,
-                displayName: model.display_name || model.id
+                displayName: model.display_name
             }))
             .sort((a, b) => a.displayName.localeCompare(b.displayName));
     }

--- a/settings.ts
+++ b/settings.ts
@@ -55,7 +55,7 @@ export class FreewritingCleanupSettingTab extends PluginSettingTab {
                         await this.refreshModels();
                     } else if (this.modelDropdown) {
                         // Show fallback immediately when key is cleared
-                        this.availableModels = await this.plugin.modelService.getAvailableModels();
+                        this.availableModels = this.plugin.modelService.getFallbackOptions();
                         this.populateModelDropdown(this.modelDropdown);
                     }
                 }))

--- a/settings.ts
+++ b/settings.ts
@@ -25,14 +25,23 @@ export class FreewritingCleanupSettingTab extends PluginSettingTab {
         this.plugin = plugin;
     }
 
-    async display(): Promise<void> {
+    display(): void {
         const { containerEl } = this;
         containerEl.empty();
 
         containerEl.createEl('h2', { text: 'Freewriting Cleanup Settings' });
 
-        // Load models asynchronously
-        await this.loadModels();
+        // Load models asynchronously in the background
+        this.loadModels()
+            .then(() => {
+                // Update dropdown UI when models are loaded
+                if (this.modelDropdown) {
+                    this.populateModelDropdown(this.modelDropdown);
+                }
+            })
+            .catch((error) => {
+                console.error('Error loading models in background:', error);
+            });
 
         // MARK: - API Configuration
 

--- a/settings.ts
+++ b/settings.ts
@@ -261,15 +261,22 @@ export class FreewritingCleanupSettingTab extends PluginSettingTab {
             if (this.modelDropdown) {
                 this.populateModelDropdown(this.modelDropdown);
 
-                // Restore selected model if it still exists
+                // Restore selected model if it still exists, otherwise use first available
                 const currentModel = this.plugin.settings.model;
                 const modelExists = this.availableModels.some(m => m.id === currentModel);
+
                 if (modelExists) {
                     this.modelDropdown.setValue(currentModel);
+                } else if (this.availableModels.length > 0) {
+                    // Model no longer available - update to first available model
+                    const newModel = this.availableModels[0].id;
+                    this.plugin.settings.model = newModel;
+                    this.modelDropdown.setValue(newModel);
+                    console.log(`Model '${currentModel}' no longer available, switched to '${newModel}'`);
                 }
             }
 
-            // Save updated cache
+            // Save updated cache and any model changes
             await this.plugin.saveSettings();
         } catch (error) {
             console.error('Error refreshing models:', error);

--- a/types.ts
+++ b/types.ts
@@ -80,16 +80,15 @@ export interface ModelCache {
     fetchedAt: number;
 }
 
-export const ANTHROPIC_MODELS = [
+// Fallback model list used when API key is not set or API fetch fails
+export const ANTHROPIC_MODELS: readonly string[] = [
     'claude-opus-4-1-20250805',
     'claude-opus-4-20250514',
     'claude-sonnet-4-20250514',
     'claude-3-7-sonnet-latest',
     'claude-3-5-haiku-latest',
     'claude-3-haiku-20240307'
-] as const;
-
-export type AnthropicModel = typeof ANTHROPIC_MODELS[number];
+];
 
 // Commentary style options
 export const COMMENTARY_STYLES = [

--- a/types.ts
+++ b/types.ts
@@ -3,11 +3,15 @@
 
 export interface FreewritingCleanupSettings {
     apiKey: string;
-    model: AnthropicModel;
+    model: string; // Changed from AnthropicModel to string to support dynamic models
     cleanupPrompt: string;
     enableCommentary: boolean;
     commentaryStyle: CommentaryStyle;
     customCommentaryPrompt: string;
+}
+
+export interface FreewritingCleanupData extends FreewritingCleanupSettings {
+    modelCache?: ModelCache;
 }
 
 export interface AnthropicMessage {
@@ -55,6 +59,25 @@ export interface CleanupResult {
         input: number;
         output: number;
     };
+}
+
+export interface ModelInfo {
+    id: string;
+    display_name?: string;
+    created_at: string;
+    type: string;
+}
+
+export interface ModelsListResponse {
+    data: ModelInfo[];
+    first_id: string;
+    has_more: boolean;
+    last_id: string;
+}
+
+export interface ModelCache {
+    models: ModelInfo[];
+    fetchedAt: number;
 }
 
 export const ANTHROPIC_MODELS = [

--- a/types.ts
+++ b/types.ts
@@ -63,7 +63,7 @@ export interface CleanupResult {
 
 export interface ModelInfo {
     id: string;
-    display_name?: string;
+    display_name: string;
     created_at: string;
     type: string;
 }


### PR DESCRIPTION
Replace hardcoded model list with dynamic API-based model fetching
that queries the Anthropic models endpoint. Implements 24-hour caching
with automatic fallback to hardcoded models if API is unavailable.

Changes:
- Add ModelService to fetch and cache available models from API
- Implement 24-hour TTL cache persisted in plugin data
- Update AnthropicClient with fetchModels() method
- Modify settings UI to load models asynchronously with loading states
- Auto-refresh models when API key is entered or changed
- Display model names using display_name field from API
- Preserve user's selected model across updates and restarts
- Show notice when falling back to hardcoded model list
- Change model type from strict enum to string for dynamic support

Technical details:
- New ModelInfo and ModelsListResponse interfaces for API response
- ModelCache interface with timestamp for TTL validation
- FreewritingCleanupData extends settings to include cache
- Settings dropdown disabled during model fetch/refresh
- Fallback to ANTHROPIC_MODELS constant on API failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic model discovery from the API with a user-facing model dropdown and remembered model cache.
  * 24-hour in-memory caching of model listings with persistence across plugin saves.

* **Improvements**
  * Settings UI auto-loads and refreshes model options when API key is entered or changed.
  * Better error handling with automatic fallback to built-in model list and surfaced usage/token info for requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->